### PR TITLE
Fix TravisCI build error due to openjdk9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 
 jdk:
   - openjdk8
-  - openjdk9
+  - openjdk10
 
 git:
   depth: false


### PR DESCRIPTION
- openjdk9: [error](https://app.travis-ci.com/github/silentsoft/badge4j/builds/245233741)
- openjdk10: [pass](https://app.travis-ci.com/github/silentsoft/badge4j/builds/245233909)